### PR TITLE
make sure value is type str before using in re.match()

### DIFF
--- a/dynamodb_json/json_util.py
+++ b/dynamodb_json/json_util.py
@@ -60,7 +60,7 @@ def object_hook(dct):
         if 'SS' in dct:
             return list(dct['SS'])
         if 'N' in dct:
-            if re.match("^-?\d+?\.\d+?$", dct['N']) is not None:
+            if re.match("^-?\d+?\.\d+?$", str(dct['N'])) is not None:
                 return float(dct['N'])
             else:
                 try:


### PR DESCRIPTION
`{"N":0.5}` is valid dynamodb json, and it is currently throwing an exception when the value `dct['N']` is used in `re.match()` because it is not type `str`

this patch makes sure the value is type `str` before using it in `re.match()`