### PR TITLE
Fix SyntaxWarning errors for python 3.12 and remove usage of long

### DIFF
--- a/dynamodb_json/json_util.py
+++ b/dynamodb_json/json_util.py
@@ -60,7 +60,7 @@ def object_hook(dct):
         if 'SS' in dct:
             return list(dct['SS'])
         if 'N' in dct:
-            if re.match("^-?\d+?\.\d+?$", dct['N']) is not None:
+            if re.match(r"^-?\d+?\.\d+?$", dct['N']) is not None:
                 return float(dct['N'])
             else:
                 try:

--- a/dynamodb_json/json_util.py
+++ b/dynamodb_json/json_util.py
@@ -19,7 +19,7 @@ def json_serial(o):
         elif o < sys.maxsize:
             serial = int(o)
         else:
-            serial = long(o)
+            serial = int(o)
     elif isinstance(o, uuid.UUID):
         serial = str(o.hex)
     elif isinstance(o, set):
@@ -99,7 +99,7 @@ def object_hook(dct):
             elif val < sys.maxsize:
                 dct[key] = int(val)
             else:
-                dct[key] = long(val)
+                dct[key] = int(val)
 
     return dct
 


### PR DESCRIPTION
This is currently raising warnings in 3.12 due to the new update. 

> A backslash-character pair that is not a valid escape sequence now generates a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning), instead of [DeprecationWarning](https://docs.python.org/3/library/exceptions.html#DeprecationWarning). For example, re.compile("\d+\.\d+") now emits a [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning) ("\d" is an invalid escape sequence, use raw strings for regular expression: re.compile(r"\d+\.\d+")).

Most importantly 
>  In a future Python version, [SyntaxError](https://docs.python.org/3/library/exceptions.html#SyntaxError) will eventually be raised, instead of [SyntaxWarning](https://docs.python.org/3/library/exceptions.html#SyntaxWarning). (Contributed by Victor Stinner in [gh-98401](https://github.com/python/cpython/issues/98401).)


Also update usages of long() since thats a python 2.x feature. 

